### PR TITLE
Add initial CI test

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -1,0 +1,21 @@
+name: Build Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Building RESTEasy with Maven
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v2
+
+    - name: Set up Java
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: Build and install RESTEasy
+      run: mvn install

--- a/jboss-modules/pom.xml
+++ b/jboss-modules/pom.xml
@@ -208,8 +208,8 @@
         </dependency>
         
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -89,29 +89,9 @@
                 </property>
             </activation>
             <modules>
-                <module>tjws</module>
                 <module>resteasy-jaxrs</module>
-                <module>resteasy-jaxrs-testsuite</module>
                 <module>resteasy-client</module>
                 <module>providers</module>
-                <module>resteasy-bom</module>
-                <module>resteasy-cache</module>
-                <module>resteasy-dependencies-bom</module>
-                <module>resteasy-guice</module>
-                <module>eagledns</module>
-                <module>security</module>
-                <module>resteasy-links</module>
-                <module>resteasy-spring</module>
-                <module>resteasy-jsapi</module>
-                <module>resteasy-cdi</module>
-                <module>resteasy-servlet-initializer</module>
-                <module>server-adapters</module>
-                <module>jboss-modules</module>
-                <module>resteasy-wadl</module>
-                <module>resteasy-wadl-undertow-connector</module>
-                <module>arquillian</module>
-                <module>profiling-tests</module>
-                <module>testsuite</module>
             </modules>
             <dependencyManagement>
                 <dependencies>
@@ -128,7 +108,6 @@
         <profile>
             <id>jsapi-testing</id>
             <modules>
-                <module>resteasy-jsapi-testing</module>
             </modules>
         </profile>
         <profile>
@@ -139,29 +118,9 @@
                 </property>
             </activation>
             <modules>
-                <module>tjws</module>
                 <module>resteasy-jaxrs</module>
-                <module>resteasy-jaxrs-testsuite</module>
                 <module>resteasy-client</module>
                 <module>providers</module>
-                <module>resteasy-bom</module>
-                <module>resteasy-cache</module>
-                <module>resteasy-dependencies-bom</module>
-                <module>resteasy-guice</module>
-                <module>eagledns</module>
-                <module>security</module>
-                <module>resteasy-links</module>
-                <module>resteasy-spring</module>
-                <module>resteasy-jsapi</module>
-                <module>resteasy-cdi</module>
-                <module>resteasy-servlet-initializer</module>
-                <module>server-adapters</module>
-                <module>jboss-modules</module>
-                <module>resteasy-wadl</module>
-                <module>resteasy-wadl-undertow-connector</module>
-                <module>arquillian</module>
-                <module>profiling-tests</module>
-                <module>testsuite</module>
             </modules>
             <dependencyManagement>
                 <dependencies>
@@ -232,34 +191,5 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>com.atlassian.maven.plugins</groupId>
-                <artifactId>maven-clover2-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>i18n cleanup</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                        <configuration>
-                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
-                            <filesets>
-                                <fileset>
-                                    <directory>src/main/resources</directory>
-                                    <includes>
-                                        <include>org/**</include>
-                                    </includes>
-                                </fileset>
-                            </filesets>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
     </build>
 </project>

--- a/providers/jaxb/pom.xml
+++ b/providers/jaxb/pom.xml
@@ -34,9 +34,9 @@
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
-            <scope>test</scope>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>1.3.5</version>
         </dependency>
        <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/providers/pom.xml
+++ b/providers/pom.xml
@@ -20,16 +20,8 @@
             </activation>
             <modules>
                 <module>jaxb</module>
-                <module>jettison</module>
-                <module>fastinfoset</module>
-                <module>jackson</module>
                 <module>jackson2</module>
-                <module>json-p-ee7</module>
                 <module>resteasy-atom</module>
-                <module>multipart</module>
-                <module>yaml</module>
-                <module>resteasy-html</module>
-                <module>resteasy-validator-provider-11</module>
             </modules>
         </profile>
     </profiles>

--- a/resteasy-dependencies-bom/pom.xml
+++ b/resteasy-dependencies-bom/pom.xml
@@ -54,7 +54,7 @@
         <version.org.javassist>3.20.0-GA</version.org.javassist>
         <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-annotations>2.0.1.Final</version.org.jboss.logging.jboss-logging-annotations>
-        <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
+        <version.jakarta.annotation.jakarta.annotation-api>1.3.5</version.jakarta.annotation.jakarta.annotation-api>
         <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>1.0.7.Final</version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
         <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.0.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
         <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
@@ -160,9 +160,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.spec.javax.annotation</groupId>
-                <artifactId>jboss-annotations-api_1.2_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec}</version>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${version.jakarta.annotation.jakarta.annotation-api}</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/resteasy-guice/pom.xml
+++ b/resteasy-guice/pom.xml
@@ -45,8 +45,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/resteasy-jaxrs/pom.xml
+++ b/resteasy-jaxrs/pom.xml
@@ -55,8 +55,9 @@
            detected runtime?
         -->
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>1.3.5</version>
             <scope>compile</scope>
         </dependency>
 

--- a/resteasy-jaxrs/pom.xml
+++ b/resteasy-jaxrs/pom.xml
@@ -18,6 +18,12 @@
     
     <dependencies>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.12</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
         </dependency>

--- a/resteasy-jsapi-testing/pom.xml
+++ b/resteasy-jsapi-testing/pom.xml
@@ -58,9 +58,8 @@
             <artifactId>httpclient</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.2</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/resteasy-links/pom.xml
+++ b/resteasy-links/pom.xml
@@ -70,8 +70,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         
         <dependency>

--- a/resteasy-spring/pom.xml
+++ b/resteasy-spring/pom.xml
@@ -117,8 +117,8 @@
            detected runtime?
         -->
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <!-- javax.activation.DataSource provider is required by spec -->

--- a/security/keystone/keystone-core/pom.xml
+++ b/security/keystone/keystone-core/pom.xml
@@ -90,8 +90,8 @@
             <artifactId>bcmail-jdk15on</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/security/resteasy-crypto/pom.xml
+++ b/security/resteasy-crypto/pom.xml
@@ -74,8 +74,8 @@
             <artifactId>apache-mime4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/security/skeleton-key-idm/skeleton-key-core/pom.xml
+++ b/security/skeleton-key-idm/skeleton-key-core/pom.xml
@@ -54,8 +54,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/security/skeleton-key-idm/skeleton-key-idp/pom.xml
+++ b/security/skeleton-key-idm/skeleton-key-idp/pom.xml
@@ -81,8 +81,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/server-adapters/resteasy-jdk-http/pom.xml
+++ b/server-adapters/resteasy-jdk-http/pom.xml
@@ -35,8 +35,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.annotation</groupId>
-            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
To simplify RESTEasy maintenance in Fedora, the upstream RESTEasy repository has been forked into `dogtagpki` organization:
https://github.com/dogtagpki/Resteasy

PKI-specific changes to RESTEasy will be maintained in the following branch:
https://github.com/dogtagpki/Resteasy/tree/3.0.26-pki
which is based on the following upstream tag:
https://github.com/resteasy/Resteasy/tree/3.0.26.Final

See also the wiki pages:
https://github.com/dogtagpki/Resteasy/wiki

This PR is adding the initial CI test to validate future changes to the branch (e.g. dropping JAXB dependency). Please see individual commits for details.

In the future this repository might also help to upgrade RESTEasy package in Fedora.